### PR TITLE
Add before_action in ApplicationController 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :authenticate_user!
 end


### PR DESCRIPTION
I have write : 
 $  before_action :authenticate_user! 

In application controller in a way to log by default all moves to a first log in. Next step is to skip_before_action each controller concerned.

@djegoburgo 
@AntoineLo 
